### PR TITLE
Fix Null Pointer Exception thrown when bucket is empty

### DIFF
--- a/java-example/src/main/java/StorageSample.java
+++ b/java-example/src/main/java/StorageSample.java
@@ -32,6 +32,7 @@ import com.google.api.services.storage.model.StorageObject;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 /**


### PR DESCRIPTION
This error case is surprisingly common because most people running
this example will have just created a fresh bucket explicitly for
this purpose (like I had), and running into an exception immediately
that requires debugging isn't very friendly for the user.
